### PR TITLE
Avoid declaring doc files as runtime data files

### DIFF
--- a/pem.cabal
+++ b/pem.cabal
@@ -12,7 +12,7 @@ Category:            Data
 stability:           experimental
 Cabal-Version:       >=1.8
 Homepage:            http://github.com/vincenthz/hs-pem
-data-files:          README.md
+extra-doc-files:     README.md
 extra-source-files:  Tests/pem.hs
 
 Library


### PR DESCRIPTION
`README.md` is not required as a runtime data file.
