### PR TITLE
Parsing PEM files with arbitrary wrapping

### DIFF
--- a/Data/PEM.hs
+++ b/Data/PEM.hs
@@ -8,10 +8,10 @@
 -- Read and write PEM files
 --
 module Data.PEM
-	( module Data.PEM.Types
+    ( module Data.PEM.Types
     , module Data.PEM.Writer
     , module Data.PEM.Parser
-	) where
+    ) where
 
 import Data.PEM.Types
 import Data.PEM.Writer

--- a/Tests/pem.hs
+++ b/Tests/pem.hs
@@ -43,6 +43,7 @@ testUnits = map (\(i, (p,bs)) -> testCase (show i) (pemWriteBS p @=? BC.pack bs)
 testDecodingMultiple = testCase ("multiple pems") (pemParseBS content @=? Right expected)
   where expected = [ PEM { pemName = "marker", pemHeader = [], pemContent = B.replicate 12 3 }
                    , PEM { pemName = "marker2", pemHeader = [], pemContent = B.replicate 64 0 }
+                   , PEM { pemName = "marker3", pemHeader = [], pemContent = B.pack [0..255] }
                    ]
         content = BC.pack $ unlines
             [ "some text that is not related to PEM"
@@ -57,6 +58,35 @@ testDecodingMultiple = testCase ("multiple pems") (pemParseBS content @=? Right 
             , "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
             , "AAAAAAAAAAAAAAAAAAAAAA=="
             , "-----END marker2-----"
+            , "also test unaligned content, missing padding and whitespace"
+            , "-----BEGIN marker3-----"
+            , "A"
+            , "AE"
+            , "CAw"
+            , "QFBg"
+            , "cICQo"
+            , "LDA0OD"
+            , "xAREhMU"
+            , "FRYXGBka"
+            , "GxwdHh8gI"
+            , "SIjJCUmJyg"
+            , "pKissLS4vMD"
+            , "EyMzQ1Njc4OT"
+            , "o7PD0+P0BBQkN"
+            , "ERUZHSElKS0xNT"
+            , "k9QUVJTVFVWV1hZ"
+            , "WltcXV5fYGFiY2Rl"
+            , "ZmdoaWprbG1ub3Bxc"
+            , "nN0dXZ3eHl6e3x9fn+"
+            , "AgYKDhIWGh4iJiouMjY"
+            , "6PkJGSk5SVlpeYmZqbnJ"
+            , "2en6ChoqOkpaanqKmqq6y"
+            , "trq+wsbKztLW2t7i5uru8v"
+            , "b6/wMHCw8TFxsfIycrLzM3O"
+            , "z9DR0tPU1dbX2Nna29zd3t/g"
+            , "4eLj5OXm5+jp6uvs7e7v8PHy8"
+            , "/T19vf4+         fr7/P3+/w"
+            , "-----END marker3-----"
             , "and finally some trailing text."
             ]
 


### PR DESCRIPTION
Current parsing code silently skips base64 characters if line length is not divisible by 4.  I found this when parsing the test certificate in [draft-ietf-curdle-pkix-04](https://www.ietf.org/id/draft-ietf-curdle-pkix-04.txt) which uses 66-character lines.  It took time to understand ASN.1 decoding failed because of bytes missing at odd places from the decoded PEM.

This solution replaces `decodeLenient` with identical behaviour when it comes to invalid characters and missing padding, but also:
- saves valid characters in excess from one line to the next
- fails if input length is 4n+1, so that no valid base64 character is ever ignored

Performance and memory efficiency is not as good as #4 but looks close. 
I confirmed the main reason why lazy decodeLenient is slow: bos/base64-bytestring#21.

CC @adinapoli: this is incompatible with #4, but I think PEM parsing should stay lenient, at least when it comes to whitespace and missing padding