### PR TITLE
Restore lenient parsing and allow arbitrary wrapping

### DIFF
--- a/Data/PEM/Parser.hs
+++ b/Data/PEM/Parser.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BangPatterns #-}
 -- |
 -- Module      : Data.PEM.Parser
 -- License     : BSD-style
@@ -17,9 +18,9 @@ module Data.PEM.Parser
     , pemParseLBS
     ) where
 
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.Either (partitionEithers)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Char8 as LC
 
@@ -47,32 +48,97 @@ parseOnePEM = findPem
         getPemHeaders name lbs =
             case getPemHeaderLoop lbs of
                 Left err           -> Left err
-                Right (hdrs, lbs2) -> getPemContent name hdrs [] lbs2
+                Right (hdrs, lbs2) -> getPemContent name hdrs initial lbs2
           where getPemHeaderLoop []     = Left $ Just "invalid PEM: no more content in header context"
                 getPemHeaderLoop (r:rs) = -- FIXME doesn't properly parse headers yet
                     Right ([], r:rs)
 
-        getPemContent :: String -> [(String,ByteString)] -> [BC.ByteString] -> [L.ByteString] -> Either (Maybe String) (PEM, [L.ByteString])
-        getPemContent name hdrs contentLines lbs =
+        getPemContent name hdrs !contentLines lbs =
             case lbs of
                 []     -> Left $ Just "invalid PEM: no end marker found"
                 (l:ls) -> case endMarker `prefixEat` l of
                               Nothing ->
-                                    case convertFromBase Base64 $ L.toStrict l of
-                                        Left err      -> Left $ Just ("invalid PEM: decoding failed: " ++ err)
-                                        Right content -> getPemContent name hdrs (content : contentLines) ls
+                                  let contentLines' = processOneLine contentLines l
+                                   in getPemContent name hdrs contentLines' ls
                               Just n  -> getPemName (finalizePem name hdrs contentLines) n ls
         finalizePem name hdrs contentLines nameEnd lbs
             | nameEnd /= name = Left $ Just "invalid PEM: end name doesn't match start name"
-            | otherwise       =
+            | otherwise       = do
+                chunks <- reverseAndPad contentLines
                 let pem = PEM { pemName    = name
                               , pemHeader  = hdrs
-                              , pemContent = BA.concat $ reverse contentLines }
-                 in Right (pem, lbs)
+                              , pemContent = BA.concat chunks }
+                return (pem, lbs)
 
         prefixEat prefix x =
             let (x1, x2) = L.splitAt (L.length prefix) x
              in if x1 == prefix then Just x2 else Nothing
+
+        initial = ([], Nothing)
+
+-- content parse state, holding converted chunks in reverse order and
+-- optionally some base64 characters as leftovers from one line to the next
+type CState = ([ByteString], Maybe ByteString)
+
+processOneLine :: CState -> Line -> CState
+processOneLine (content, leftovers) line =
+    go content $ maybe lineChunks (: lineChunks) leftovers
+  where
+    lineChunks = L.toChunks (LC.filter goodChar line)
+    goodChar c = isDigit c || isAsciiUpper c || isAsciiLower c
+                           || c == '+' || c == '/'
+    n = 4
+
+    build x f l xs = let !d = strictDecode x in f (d:l) xs
+    {-# INLINE build #-}
+
+    -- adapted from base64-bytestring internal reChunkIn, but also returns
+    -- base64 leftovers that could not be used at line end, and should
+    -- be used at the begining of the next line, or as part of final padding
+
+    go l []       = (l, Nothing)
+    go l (y : ys) =
+          case BA.length y `divMod` n of
+              (_, 0) -> build y go l ys
+              (0, _) -> fixup l y ys
+              (d, _) -> let (prefix, suffix) = BA.splitAt (d * n) y
+                         in build prefix fixup l suffix ys
+
+    fixup l acc []       = (l, Just acc)
+    fixup l acc (z : zs) =
+        case BA.splitAt (n - BA.length acc) z of
+            (prefix, suffix) ->
+                let acc' = acc `BA.append` prefix
+                 in if BA.length acc' == n
+                        then let zs' = if BA.null suffix
+                                           then zs
+                                           else suffix : zs
+                              in build acc' go l zs'
+                       else -- suffix must be null
+                           fixup l acc' zs
+
+-- leftovers with 0, 2 or 3 characters are valid end sequences, but
+-- only 1 character is a parse error, as this length is not valid for
+-- encoded base64 content
+reverseAndPad :: CState -> Either (Maybe String) [ByteString]
+reverseAndPad (content, leftovers) = fmap reverse (pad leftovers content)
+  where
+    pad Nothing  l = Right l
+    pad (Just b) l =
+        case BA.length b `mod` 4 of
+            3 -> Right $ strictDecode (b `BA.append` "=")  : l
+            2 -> Right $ strictDecode (b `BA.append` "==") : l
+            1 -> Left  $ Just "invalid PEM: missing or extra base64 characters"
+            _ -> Right $ strictDecode b : l
+
+-- base64 decoding that should never fail, as it is fed only with
+-- sequences of valid characters whose length is a multiple of 4
+strictDecode :: ByteString -> ByteString
+strictDecode x =
+    case convertFromBase Base64 x of
+        Left  _ -> error "parseOnePEM: invalid chunk detected"
+        Right r -> r
+{-# INLINE strictDecode #-}
 
 -- | parser to get PEM sections
 pemParse :: [Line] -> [Either String PEM]

--- a/Data/PEM/Writer.hs
+++ b/Data/PEM/Writer.hs
@@ -20,7 +20,7 @@ import           Data.ByteArray.Encoding (Base(Base64), convertToBase)
 
 -- | write a PEM structure to a builder
 pemWrite :: PEM -> L.ByteString
-pemWrite pem = L.fromChunks $ ([begin,header]++section++[end])
+pemWrite pem = L.fromChunks ([begin,header]++section++[end])
     where begin   = B.concat ["-----BEGIN ", sectionName, "-----\n"]
           end     = B.concat ["-----END ", sectionName, "-----\n" ]
           section :: [ByteString]
@@ -28,7 +28,7 @@ pemWrite pem = L.fromChunks $ ([begin,header]++section++[end])
           header :: ByteString
           header  = if null $ pemHeader pem
                         then B.empty
-                        else B.concat ((concatMap toHeader (pemHeader pem)) ++ ["\n"])
+                        else B.concat (concatMap toHeader (pemHeader pem) ++ ["\n"])
           toHeader :: (String, ByteString) -> [ByteString]
           toHeader (k,v) = [ BC.pack k, ":", v, "\n" ]
           -- expect only ASCII. need to find a type to represent it.

--- a/Tests/pem.hs
+++ b/Tests/pem.hs
@@ -43,6 +43,7 @@ testUnits = map (\(i, (p,bs)) -> testCase (show i) (pemWriteBS p @=? BC.pack bs)
 testDecodingMultiple = testCase ("multiple pems") (pemParseBS content @=? Right expected)
   where expected = [ PEM { pemName = "marker", pemHeader = [], pemContent = B.replicate 12 3 }
                    , PEM { pemName = "marker2", pemHeader = [], pemContent = B.replicate 64 0 }
+                   , PEM { pemName = "marker3", pemHeader = [], pemContent = B.pack [0..255] }
                    ]
         content = BC.pack $ unlines
             [ "some text that is not related to PEM"
@@ -57,6 +58,26 @@ testDecodingMultiple = testCase ("multiple pems") (pemParseBS content @=? Right 
             , "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
             , "AAAAAAAAAAAAAAAAAAAAAA=="
             , "-----END marker2-----"
+            , "also test unaligned content, missing padding and whitespace"
+            , "-----BEGIN marker3-----"
+            , "                                             "
+            , " AAECAwQ  FBgcICQo                           "
+            , "  LDA0ODx  AREhMUFR                          "
+            , "   YXGBkaG  xwdHh8gI                         "
+            , "    SIjJCUm  JygpKiss                        "
+            , "     LS4vMDE  yMzQ1Njc  4OTo7PD0+P0BBQ       "
+            , "      kNERUZH  SElKS0xN  Tk9QUVJTVFVWV1      "
+            , "       hZWltcX  V5fYGFiY  2RlZmdoaWprbG1     "
+            , "        ub3Bxcn  N0dXZ3eH                    "
+            , "        l6e3x9f  n+AgYKDhI  WGh4iJiouMjY6P   "
+            , "       kJGSk5S  VlpeYmZqbnJ  2en6ChoqOkpaan  "
+            , "      qKmqq6y  trq+wsbKztLW2  t7i5uru8vb6/wM "
+            , "     HCw8TFx  sfIycrL zM3Oz9D                "
+            , "    R0tPU1d  bX2Nna2   9zd3t/g               "
+            , "   4eLj5OX  m5+jp6u     vs7e7v8              "
+            , "  PHy8/T1  9vf4+fr       7/P3+/w             "
+            , "                                             "
+            , "-----END marker3-----"
             , "and finally some trailing text."
             ]
 

--- a/Tests/pem.hs
+++ b/Tests/pem.hs
@@ -4,7 +4,7 @@ import Control.Applicative
 import Control.Monad
 
 import qualified Data.ByteString.Char8 as BC
-import Test.QuickCheck hiding ((.&.))
+import Test.QuickCheck
 import Test.Framework (Test, defaultMain, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.Framework.Providers.HUnit (testCase)
@@ -18,7 +18,7 @@ main = defaultMain tests
 
 tests :: [Test]
 tests =
-    [ testGroup "units" $ testUnits
+    [ testGroup "units" testUnits
     , testDecodingMultiple
     , testUnmatchingNames
     , testProperty "marshall" testMarshall
@@ -40,7 +40,7 @@ testUnits = map (\(i, (p,bs)) -> testCase (show i) (pemWriteBS p @=? BC.pack bs)
                 , "-----END xxx-----"
                 ]
 
-testDecodingMultiple = testCase ("multiple pems") (pemParseBS content @=? Right expected)
+testDecodingMultiple = testCase "multiple pems" (pemParseBS content @=? Right expected)
   where expected = [ PEM { pemName = "marker", pemHeader = [], pemContent = B.replicate 12 3 }
                    , PEM { pemName = "marker2", pemHeader = [], pemContent = B.replicate 64 0 }
                    , PEM { pemName = "marker3", pemHeader = [], pemContent = B.pack [0..255] }


### PR DESCRIPTION
This is to replace #5, this time on top of memory base64 implementation instead of byte64-bytestring.

It should also fix #8 as side effect.